### PR TITLE
Support comma-separated format strings for multi-parser fallback

### DIFF
--- a/src/core/parse_content.cpp
+++ b/src/core/parse_content.cpp
@@ -5,8 +5,29 @@
 #include "../parsers/tool_outputs/regexp_parser.hpp"
 #include "../parsers/config_based/config_parser.hpp"
 #include <algorithm>
+#include <sstream>
 
 namespace duckdb {
+
+// Split a comma-separated format string into individual format names.
+// Trims whitespace from each entry. Returns empty vector if no commas found.
+static std::vector<std::string> SplitFormatList(const std::string &format_name) {
+	if (format_name.find(',') == std::string::npos) {
+		return {};
+	}
+	std::vector<std::string> formats;
+	std::istringstream stream(format_name);
+	std::string token;
+	while (std::getline(stream, token, ',')) {
+		// Trim whitespace
+		size_t start = token.find_first_not_of(" \t");
+		size_t end = token.find_last_not_of(" \t");
+		if (start != std::string::npos) {
+			formats.push_back(token.substr(start, end - start + 1));
+		}
+	}
+	return formats;
+}
 
 // Check if format string looks like a config file path
 static bool IsConfigFilePath(const std::string &format_name) {
@@ -47,6 +68,19 @@ std::vector<ValidationEvent> ParseContent(ClientContext &context, const std::str
 
 	if (format_name.empty() || format_name == "unknown" || format_name == "auto") {
 		return events; // Invalid format, return empty
+	}
+
+	// Check for comma-separated format list (e.g., "gcc_text,make_error,cake_error")
+	// Try each format in order, return events from first one that produces results.
+	auto format_list = SplitFormatList(format_name);
+	if (!format_list.empty()) {
+		for (const auto &fmt : format_list) {
+			auto fmt_events = ParseContent(context, content, fmt);
+			if (!fmt_events.empty()) {
+				return fmt_events;
+			}
+		}
+		return events; // No format in list produced events
 	}
 
 	// Check if this is an inline config file path
@@ -140,6 +174,17 @@ bool IsValidFormat(const std::string &format_name) {
 		return true; // "auto" is always valid
 	}
 
+	// Comma-separated format lists: each entry must be valid
+	auto format_list = SplitFormatList(format_name);
+	if (!format_list.empty()) {
+		for (const auto &fmt : format_list) {
+			if (!IsValidFormat(fmt)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	// Config file paths are valid format specifiers
 	if (IsConfigFilePath(format_name)) {
 		return true;
@@ -161,6 +206,18 @@ std::vector<ValidationEvent> ParseFile(ClientContext &context, const std::string
 	std::vector<ValidationEvent> events;
 
 	if (format_name.empty() || format_name == "unknown" || format_name == "auto") {
+		return events;
+	}
+
+	// Check for comma-separated format list
+	auto format_list = SplitFormatList(format_name);
+	if (!format_list.empty()) {
+		for (const auto &fmt : format_list) {
+			auto fmt_events = ParseFile(context, file_path, fmt);
+			if (!fmt_events.empty()) {
+				return fmt_events;
+			}
+		}
 		return events;
 	}
 

--- a/src/read_duck_hunt_log_function.cpp
+++ b/src/read_duck_hunt_log_function.cpp
@@ -78,11 +78,10 @@ unique_ptr<FunctionData> ReadDuckHuntLogBind(ClientContext &context, TableFuncti
 	} else if (input.inputs.size() == 1 && !input.inputs[0].IsNull()) {
 		// Could be single-arg call with literal source, or two-arg LATERAL with column ref source
 		std::string val = input.inputs[0].ToString();
-		// Check if this looks like a format (not a file path)
-		auto &registry = ParserRegistry::getInstance();
-		auto test_format = StringToTestResultFormat(val);
-		if (test_format != TestResultFormat::UNKNOWN || registry.hasFormat(val) || registry.isGroup(val) ||
-		    val == "auto") {
+		// Check if this looks like a format (not a file path).
+		// IsValidFormat handles known formats, aliases, groups, config paths,
+		// comma-separated lists, and "auto".
+		if (IsValidFormat(val)) {
 			format_str = val;
 			has_format = true;
 			bind_data->source = ""; // Source will come from DataChunk
@@ -442,13 +441,11 @@ unique_ptr<FunctionData> ParseDuckHuntLogBind(ClientContext &context, TableFunct
 		has_format = true;
 	} else if (input.inputs.size() == 1 && !input.inputs[0].IsNull()) {
 		// Could be single-arg call with literal source, or two-arg LATERAL with column ref source
-		// Check if this looks like a format (not a file path)
 		std::string val = input.inputs[0].ToString();
-		// If it doesn't look like a path (no slashes, dots suggesting extensions) and is a known format
-		auto &registry = ParserRegistry::getInstance();
-		auto test_format = StringToTestResultFormat(val);
-		if (test_format != TestResultFormat::UNKNOWN || registry.hasFormat(val) || registry.isGroup(val) ||
-		    val == "auto") {
+		// Check if this looks like a format (not a file path).
+		// IsValidFormat handles known formats, aliases, groups, config paths,
+		// comma-separated lists, and "auto".
+		if (IsValidFormat(val)) {
 			format_str = val;
 			has_format = true;
 			bind_data->source = ""; // Source will come from DataChunk

--- a/src/read_duck_hunt_log_function.cpp
+++ b/src/read_duck_hunt_log_function.cpp
@@ -101,17 +101,13 @@ unique_ptr<FunctionData> ReadDuckHuntLogBind(ClientContext &context, TableFuncti
 			bind_data->format_name = format_str; // Use original string for registry-only formats
 		}
 
-		// Check for unknown format - but allow registry-only formats, format groups, and config file paths
+		// Check for unknown format - but allow registry-only formats, format groups,
+		// config file paths, and comma-separated format lists
 		if (bind_data->format == TestResultFormat::UNKNOWN) {
-			// Check if this format exists in the new parser registry or is a format group
-			auto &registry = ParserRegistry::getInstance();
-			bool is_config_path = (format_str.substr(0, 7) == "config:" ||
-			                       (format_str.length() > 5 && format_str.substr(format_str.length() - 5) == ".json"));
-			if (!registry.hasFormat(format_str) && !registry.isGroup(format_str) && !is_config_path) {
+			if (!IsValidFormat(format_str)) {
 				throw BinderException("Unknown format: '" + format_str +
 				                      "'. Use 'auto' for auto-detection or see docs/formats.md for supported formats.");
 			}
-			// Format exists in registry, is a group, or is a config file path
 		}
 
 		// For REGEXP format, extract the pattern after the "regexp:" prefix
@@ -471,17 +467,13 @@ unique_ptr<FunctionData> ParseDuckHuntLogBind(ClientContext &context, TableFunct
 			bind_data->format_name = format_str; // Use original string for registry-only formats
 		}
 
-		// Check for unknown format - but allow registry-only formats, format groups, and config file paths
+		// Check for unknown format - but allow registry-only formats, format groups,
+		// config file paths, and comma-separated format lists
 		if (bind_data->format == TestResultFormat::UNKNOWN) {
-			// Check if this format exists in the new parser registry or is a format group
-			auto &registry = ParserRegistry::getInstance();
-			bool is_config_path = (format_str.substr(0, 7) == "config:" ||
-			                       (format_str.length() > 5 && format_str.substr(format_str.length() - 5) == ".json"));
-			if (!registry.hasFormat(format_str) && !registry.isGroup(format_str) && !is_config_path) {
+			if (!IsValidFormat(format_str)) {
 				throw BinderException("Unknown format: '" + format_str +
 				                      "'. Use 'auto' for auto-detection or see docs/formats.md for supported formats.");
 			}
-			// Format exists in registry, is a group, or is a config file path
 		}
 
 		// For REGEXP format, extract the pattern after the "regexp:" prefix

--- a/test/sql/make_parser.test
+++ b/test/sql/make_parser.test
@@ -229,6 +229,31 @@ make: *** [Makefile:169: release] Error 2', 'gcc_text,make_error');
 make	build.make
 make	Makefile
 
+# Test: Trailing comma is tolerated (empty token silently dropped)
+query I
+SELECT tool_name FROM parse_duck_hunt_log('file.cpp:1:1: error: test', 'gcc_text,');
+----
+compiler
+
+# Test: Double comma is tolerated (empty token silently dropped)
+query I
+SELECT tool_name FROM parse_duck_hunt_log('file.cpp:1:1: error: test', 'gcc_text,,make_error');
+----
+compiler
+
+# Test: "auto" inside a comma list is rejected (it would be a silent no-op)
+statement error
+SELECT * FROM parse_duck_hunt_log('test', 'gcc_text,auto');
+----
+Unknown format
+
+# Test: LATERAL join with comma-separated format
+query I
+SELECT tool_name FROM (VALUES ('file.cpp:1:1: error: test')) t(log),
+  parse_duck_hunt_log(t.log, 'gcc_text,make_error');
+----
+compiler
+
 # =============================================================================
 # REALISTIC BUILD LOG (full scenario from plinking_duck)
 # =============================================================================

--- a/test/sql/make_parser.test
+++ b/test/sql/make_parser.test
@@ -166,30 +166,68 @@ make: *** [Makefile:169: release] Error 2', 'make_error');
 2
 
 # =============================================================================
-# COMMA-SEPARATED FORMAT (currently unsupported)
+# COMMA-SEPARATED FORMAT LIST
 # =============================================================================
 
-# Test: Comma-separated format strings are NOT supported by duck_hunt.
+# Comma-separated format strings try each format in order (first-match-wins).
 # This is the format used in plinking_duck's .lq/commands.toml:
 #   format = "gcc_text,make_error,cake_error"
-# duck_hunt throws BinderException for unknown format names.
-# blq catches this silently and returns zero events.
 
-statement error
-SELECT * FROM parse_duck_hunt_log('test', 'gcc_text,make_error');
-----
-Unknown format
-
-# Test: Each individual format works fine
+# Test: First format in list matches — gcc_text handles compiler diagnostics
 query I
-SELECT tool_name FROM parse_duck_hunt_log('file.cpp:1:1: error: test', 'gcc_text');
+SELECT tool_name FROM parse_duck_hunt_log('file.cpp:1:1: error: test', 'gcc_text,make_error');
 ----
 compiler
 
+# Test: Fallback to second format — make_error handles when gcc_text finds nothing
 query I
-SELECT tool_name FROM parse_duck_hunt_log('make: *** [Makefile:10: all] Error 2', 'make_error');
+SELECT tool_name FROM parse_duck_hunt_log('make: *** [Makefile:10: all] Error 2', 'gcc_text,make_error');
 ----
 make
+
+# Test: Order matters — make_error is tried first
+query I
+SELECT tool_name FROM parse_duck_hunt_log(
+'file.cpp:1:1: error: test
+make: *** [Makefile:10: all] Error 2', 'make_error,gcc_text');
+----
+make
+
+# Test: Whitespace around commas is tolerated
+query I
+SELECT tool_name FROM parse_duck_hunt_log('file.cpp:1:1: error: test', 'gcc_text , make_error');
+----
+compiler
+
+# Test: Three formats (the actual plinking_duck config pattern)
+query I
+SELECT tool_name FROM parse_duck_hunt_log('file.cpp:1:1: error: test', 'gcc_text,make_error,cmake_build');
+----
+compiler
+
+# Test: Invalid format in list is rejected at bind time
+statement error
+SELECT * FROM parse_duck_hunt_log('test', 'gcc_text,bogus_format');
+----
+Unknown format
+
+# Test: Comma-separated with mixed GCC+make content picks GCC (first in list)
+query IIII
+SELECT tool_name, ref_file, ref_line, message FROM parse_duck_hunt_log(
+'/home/user/src/file.cpp:6:10: fatal error: missing.hpp: No such file or directory
+gmake[3]: *** [build.make:121: file.cpp.o] Error 1
+make: *** [Makefile:169: release] Error 2', 'gcc_text,make_error');
+----
+compiler	/home/user/src/file.cpp	6	missing.hpp: No such file or directory
+
+# Test: Comma-separated with only make errors falls through to make_error
+query II
+SELECT tool_name, ref_file FROM parse_duck_hunt_log(
+'gmake[3]: *** [build.make:121: file.cpp.o] Error 1
+make: *** [Makefile:169: release] Error 2', 'gcc_text,make_error');
+----
+make	build.make
+make	Makefile
 
 # =============================================================================
 # REALISTIC BUILD LOG (full scenario from plinking_duck)


### PR DESCRIPTION
## Summary

Fixes #47.

- Format strings like `"gcc_text,make_error,cmake_build"` now try each parser in order, returning events from the first that produces results (first-match-wins)
- Unblocks plinking_duck's `.lq/commands.toml` which configures `format = "gcc_text,make_error,cake_error"` — previously this threw a BinderException that blq caught silently, resulting in zero parsed events
- Simplifies bind-time format validation in both `read_duck_hunt_log` and `parse_duck_hunt_log` to use the shared `IsValidFormat` function

## Test plan

- [x] First format matches: `'gcc_text,make_error'` returns GCC events for compiler diagnostics
- [x] Fallback works: `'gcc_text,make_error'` returns make events when no GCC diagnostics present
- [x] Order respected: `'make_error,gcc_text'` tries make_error first
- [x] Whitespace tolerated: `'gcc_text , make_error'` works
- [x] Three formats: `'gcc_text,make_error,cmake_build'` works
- [x] Invalid format in list rejected: `'gcc_text,bogus_format'` throws BinderException
- [x] Mixed content: GCC+make log with `'gcc_text,make_error'` extracts source file reference
- [x] All 55 existing test files pass (0 failures, 2 expected skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)