### PR TITLE
test(wasm): treat all duckdb_* namespaces as host-provided

### DIFF
--- a/test/wasm/README.md
+++ b/test/wasm/README.md
@@ -50,11 +50,15 @@ is a forward-looking regression guard, not a fix.**
 Because there are no static deps to *forbid*, the meaningful check is the
 inverse — an **allowlist**. `check_wasm_imports.mjs` parses the built `.wasm`
 (validate-only, **no instantiation**) and fails if any not-self-resolved
-**C++-mangled** symbol appears outside the known host-provided set
-(`duckdb::`, `duckdb_yyjson::`, `std::`/`__gnu_cxx`/`__cxxabiv1`, typeinfo/vtable,
-operator new/delete). That flags the day someone adds a vcpkg dependency
-without wiring `LINKED_LIBS`: its symbols would appear as a new foreign
-namespace and trip the check.
+**C++-mangled** symbol appears outside the known host-provided set: any
+`duckdb`-prefixed namespace (the runtime plus its vendored third_party —
+`duckdb_yyjson`, `duckdb_zstd`, `duckdb_re2`, `duckdb_miniz`, …, all exported by
+the duckdb-wasm host), `std::`/`__gnu_cxx`/`__cxxabiv1`, typeinfo/vtable, and
+operator new/delete. That flags the day someone adds a vcpkg dependency without
+wiring `LINKED_LIBS`: its symbols appear under a new foreign namespace and trip
+the check. (The `duckdb_*` prefix is matched as a family on purpose — a hardcoded
+`duckdb_yyjson`-only list false-positives other bundled libs like `duckdb_zstd`,
+which a zstd-using extension such as `scalarfs` legitimately imports from the host.)
 
 Subtleties (same as the sibling harnesses):
 

--- a/test/wasm/selftest.mjs
+++ b/test/wasm/selftest.mjs
@@ -32,6 +32,7 @@ const MUST_BE_ALLOWED = [
   "_ZN6duckdb9ExceptionC2ENS_13ExceptionTypeERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE", // duckdb::Exception ctor
   "_ZN6duckdb10StringUtil7ReplaceENS_6stringERKS1_S3_",                  // duckdb::StringUtil::Replace
   "_ZN13duckdb_yyjson16yyjson_read_optsEPcmjPKNS_10yyjson_alcEPNS_15yyjson_read_errE", // host yyjson
+  "_ZN11duckdb_zstd18ZSTD_createDStreamEv",                              // host duckdb_zstd (e.g. scalarfs) — bundled third_party
   "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKcm",   // std::string::append
   "_ZSt19__throw_logic_errorPKc",                                        // std::__throw_logic_error
   "_ZTVSt12length_error",                                                // vtable for std::length_error

--- a/test/wasm/wasm_symbol_classify.mjs
+++ b/test/wasm/wasm_symbol_classify.mjs
@@ -56,6 +56,14 @@ export function classify(name) {
 export function hostAllowed(name, extraAllow = []) {
   const c = classify(name);
   if (c === "operator" || c === "std" || c === "std-sub") return true;
-  if (c !== null && ALLOWED_NS.has(c)) return true;
+  // Any "duckdb"-prefixed namespace is host-provided: the duckdb-wasm runtime
+  // exports its own symbols AND its vendored third_party, which all live under a
+  // duckdb_* namespace (duckdb_yyjson, duckdb_zstd, duckdb_re2, duckdb_miniz, ...).
+  // Verified against the host module's export table — e.g. scalarfs imports
+  // duckdb_zstd::ZSTD_* and the host exports every one of them. A hardcoded list
+  // (duckdb_yyjson only) would FALSE-POSITIVE any other bundled lib (zstd, re2).
+  // Real foreign deps never use a duckdb_ prefix (yaml-cpp=YAML, libxml2=xml,
+  // cmark=cmark), so the prefix match cannot mask a genuine missing dependency.
+  if (c !== null && (c === "duckdb" || c.startsWith("duckdb_") || ALLOWED_NS.has(c))) return true;
   return extraAllow.some((re) => re.test(name));
 }


### PR DESCRIPTION
test(wasm): treat all duckdb_* namespaces as host-provided in the symbol checker

The Layer-1 allowlist hardcoded only `duckdb` and `duckdb_yyjson` as
host-provided, so it false-positived on any other duckdb-bundled third_party
library. Confirmed empirically: the duckdb-wasm host module exports the full
duckdb_zstd ZSTD_* API (and yyjson), and a zstd-using extension like scalarfs
imports duckdb_zstd::ZSTD_* from the host exactly as duck_hunt imports yyjson —
the old checker wrongly flagged those 9 symbols as foreign.

Fix: allow any `duckdb`-prefixed leading namespace (the runtime plus its vendored
third_party: duckdb_yyjson, duckdb_zstd, duckdb_re2, duckdb_miniz, ...). Real
foreign deps never use a duckdb_ prefix (yaml-cpp=YAML, libxml2=xml, cmark=cmark),
so this can't mask a genuine missing dependency. Added a duckdb_zstd fixture to
selftest.mjs and updated the README.

Verified: scalarfs.wasm now reports 0 foreign (was 9); duck_hunt and markdown
stay 0; selftest passes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
