### PR TITLE
pytest_text: keep the block-derived message over a truncated summary

### DIFF
--- a/src/parsers/test_frameworks/pytest_parser.cpp
+++ b/src/parsers/test_frameworks/pytest_parser.cpp
@@ -387,10 +387,8 @@ void PytestParser::parseTestLine(const std::string &line, int64_t &event_id, std
 			// than a short real message like "boom", so a length comparison
 			// alone would leave the placeholder in place.
 			if (!it->second.error_message.empty()) {
-				const bool is_placeholder =
-				    (event.message == "Test failed" || event.message == "Test error");
-				const bool block_says_more =
-				    it->second.error_message.size() > event.message.size();
+				const bool is_placeholder = (event.message == "Test failed" || event.message == "Test error");
+				const bool block_says_more = it->second.error_message.size() > event.message.size();
 				if (is_placeholder || block_says_more) {
 					event.message = it->second.error_message;
 				}

--- a/src/parsers/test_frameworks/pytest_parser.cpp
+++ b/src/parsers/test_frameworks/pytest_parser.cpp
@@ -368,10 +368,32 @@ void PytestParser::parseTestLine(const std::string &line, int64_t &event_id, std
 			if (!it->second.file.empty()) {
 				event.ref_file = it->second.file;
 			}
-			// Enhance message with error details if available
-			if (!it->second.error_message.empty() &&
-			    (event.message == "Test failed" || event.message == "Test error")) {
-				event.message = it->second.error_message;
+			// Enhance message with error details if available.
+			//
+			// The block-derived message wins whenever it carries MORE than what
+			// we already have, not only when the message is still a placeholder.
+			//
+			// `pytest -q` abbreviates its short-summary line to the terminal
+			// width, assuming 80 columns when there is no TTY — which is always
+			// under a capturing runner. That line is where Format 2 gets its
+			// message, so what survives is 80 columns minus the "FAILED
+			// file.py::test_name - " prefix: a 73-character prefix leaves 7
+			// characters, and the stored message is "asse...". The old
+			// placeholder-only condition meant the truncated text, having
+			// already been assigned, blocked the complete message we had
+			// parsed out of the FAILURES block a few lines above.
+			//
+			// The placeholder case is kept explicitly: "Test failed" is longer
+			// than a short real message like "boom", so a length comparison
+			// alone would leave the placeholder in place.
+			if (!it->second.error_message.empty()) {
+				const bool is_placeholder =
+				    (event.message == "Test failed" || event.message == "Test error");
+				const bool block_says_more =
+				    it->second.error_message.size() > event.message.size();
+				if (is_placeholder || block_says_more) {
+					event.message = it->second.error_message;
+				}
 			}
 			// Update log_line_start/end to point to the FAILURES section traceback
 			// This makes context extraction show the actual failure details

--- a/test/sql/pytest_parser.test
+++ b/test/sql/pytest_parser.test
@@ -143,3 +143,24 @@ SELECT message FROM parse_duck_hunt_log(E'=================================== FA
 WHERE status = 'FAIL';
 ----
 assert None == 5
+
+# Test: a summary that is LONGER than the block message is preserved. This is
+# the guard against the fix losing information in the other direction — the
+# enrichment must only fire when the block carries more, never merely because
+# it is different.
+query I
+SELECT message FROM parse_duck_hunt_log(E'=================================== FAILURES ===================================\n_______________ test_beta ________________\n\ntests/test_b.py:9: in test_beta\n    assert other() is None\nE   AssertionError: expected None\n\n=========================== short test summary info ============================\nFAILED tests/test_b.py::test_beta - AssertionError: expected None, and here is a great deal more context\n================== 1 failed in 0.01s ===================', 'pytest_text')
+WHERE status = 'FAIL';
+----
+AssertionError: expected None, and here is a great deal more context
+
+# Test: only the FIRST `E ` line reaches `message`. The follow-on
+# "+ where ..." line names the function under test and is NOT captured here —
+# it survives in log_content, and widening this is tracked separately rather
+# than changed under a truncation fix, since it would make messages multi-line
+# for every consumer.
+query I
+SELECT message FROM parse_duck_hunt_log(E'=================================== FAILURES ===================================\n_______________ test_alpha ________________\n\ntests/test_a.py:5: in test_alpha\n    assert compute(1) == 99\nE   assert 1 == 99\nE    +  where 1 = compute(1)\n\n=========================== short test summary info ============================\nFAILED tests/test_a.py::test_alpha - asse...\n================== 1 failed in 0.01s ===================', 'pytest_text')
+WHERE status = 'FAIL';
+----
+assert 1 == 99

--- a/test/sql/pytest_parser.test
+++ b/test/sql/pytest_parser.test
@@ -103,3 +103,43 @@ SELECT status, message FROM parse_duck_hunt_log(E'tests/test_example.py::test_ba
 WHERE status = 'FAIL';
 ----
 FAIL	Test failed
+
+# =============================================================================
+# TRUNCATED SUMMARY LINE (issue #57)
+# =============================================================================
+#
+# `pytest -q` abbreviates its short-summary line to the terminal width and
+# assumes 80 columns when there is no TTY — which is always, under a capturing
+# runner. What survives is 80 columns minus the "FAILED file::test - " prefix,
+# so a long test name leaves almost nothing:
+#
+#   FAILED tests/test_priority.py::test_unknown_name_falls_back_to_default - asse...
+#
+# The parser already reads the complete message out of the FAILURES block. It
+# used to discard it, because the enrichment only fired while the message was
+# still a placeholder and the truncated summary had already replaced that. The
+# result was that a failure's diagnosability depended on how long someone had
+# named the test.
+
+# Test: a truncated summary is replaced by the message parsed from the block.
+query I
+SELECT message FROM parse_duck_hunt_log(E'=================================== FAILURES ===================================\n_______________ test_unknown_name_falls_back_to_default ________________\n\ntests/test_priority.py:5: in test_unknown_name_falls_back_to_default\n    assert normalize(5) == 5\nE   assert None == 5\n\n=========================== short test summary info ============================\nFAILED tests/test_priority.py::test_unknown_name_falls_back_to_default - asse...\n================== 1 failed in 0.01s ===================', 'pytest_text')
+WHERE status = 'FAIL';
+----
+assert None == 5
+
+# Test: an untruncated summary that is already complete is left alone, so a
+# short test name behaves exactly as before.
+query I
+SELECT message FROM parse_duck_hunt_log(E'=================================== FAILURES ===================================\n_______________ test_thing ________________\n\ntest_thing.py:5: in test_thing\n    assert None == 5\nE   assert None == 5\n\n=========================== short test summary info ============================\nFAILED test_thing.py::test_thing - assert None == 5\n================== 1 failed in 0.01s ===================', 'pytest_text')
+WHERE status = 'FAIL';
+----
+assert None == 5
+
+# Test: the placeholder path still works — no " - message" on the summary line
+# at all, so the block supplies the whole message.
+query I
+SELECT message FROM parse_duck_hunt_log(E'=================================== FAILURES ===================================\n_______________ test_thing ________________\n\ntest_thing.py:5: in test_thing\n    assert None == 5\nE   assert None == 5\n\n=========================== short test summary info ============================\nFAILED test_thing.py::test_thing\n================== 1 failed in 0.01s ===================', 'pytest_text')
+WHERE status = 'FAIL';
+----
+assert None == 5


### PR DESCRIPTION
Fixes #57.

`PytestParser` already parses the `=== FAILURES ===` block and extracts the error message from it, then discarded that message whenever the summary line had already set one — which is exactly the case where the summary is truncated.

## The mechanism

`pytest -q` abbreviates its short-summary line to the terminal width, assuming 80 columns when there is no TTY, which is always true under a capturing runner. Format 2 takes its message from that line, so what survives is 80 columns minus the `FAILED file.py::test_name - ` prefix:

| test name | message that survives |
|---|---|
| 73 characters | **7** — `asse...` |
| 35 characters | 45 — nothing lost |

So how diagnosable a failure was depended on how long someone had named the test.

## The change

The enrichment now fires when the block-derived message carries *more* than what we already have, not only while the message is still a placeholder:

```cpp
if (!it->second.error_message.empty()) {
    const bool is_placeholder =
        (event.message == "Test failed" || event.message == "Test error");
    const bool block_says_more =
        it->second.error_message.size() > event.message.size();
    if (is_placeholder || block_says_more) {
        event.message = it->second.error_message;
    }
}
```

The placeholder case is kept explicitly rather than folded into the length test: `"Test failed"` is longer than a short real message like `"boom"`, so a length comparison alone would leave the placeholder in place. Nothing is lost in the other direction either — a summary already longer than the block message is preserved.

## Verification

- **Real pytest output, end to end.** pytest emitted `FAILED tests/test_priority.py::test_unknown_name_falls_back_to_default - asse...`; the rebuilt extension parses it to `assert None == 5` (16 chars), with `ref_file`/`ref_line` unchanged.
- **Three SQL cases added** to `test/sql/pytest_parser.test`: truncated summary, already-complete summary (must be left alone), and the placeholder path.
- **Full suite: 3576 assertions across 51 test cases, all passing**, built from source at `-j4`.
- The decision table was also exercised standalone before building, covering summary-longer-than-block and empty-block cases that the SQL fixtures do not reach.

## Context

This surfaced downstream as teaguesterling/blq-cli#49, where the truncation was first mistaken for a storage bug — three sessions produced four different mechanisms for the same seven-character string before someone read pytest's own output. blq shipped a wide-`COLUMNS` capture default as defence-in-depth (1.1.0), but this is the root fix: no parser can recover text the tool never printed, and here the tool *did* print it, into the block a few lines above.
